### PR TITLE
Fix Acala event address filters

### DIFF
--- a/packages/acala-evm/src/index.spec.ts
+++ b/packages/acala-evm/src/index.spec.ts
@@ -60,6 +60,7 @@ describe('AcalaDS', () => {
       let event: SubstrateEvent;
 
       beforeEach(async () => {
+        // https://acala-testnet.subscan.io/event?block=927886
         const blockNumber = 927886;
         const {events} = await fetchBlock(api, blockNumber);
 


### PR DESCRIPTION
Fixes using the receipt address value to compare to filter address.
It will now use the event address.
This would cause an issue if a contract would call another contract internally that would emit an event.