### PR TITLE
remove provider from the bundle

### DIFF
--- a/packages/acala-evm/package.json
+++ b/packages/acala-evm/package.json
@@ -7,7 +7,7 @@
   "license": "Apache-2.0",
   "scripts": {
     "build:ts": "tsc -b",
-    "build:bundle": "esbuild src/index.ts --platform=node --bundle --format=cjs --minify --outfile=dist/bundle.js",
+    "build:bundle": "esbuild src/bundle.ts --platform=node --bundle --format=cjs --minify --outfile=dist/bundle.js",
     "build": "yarn build:ts && yarn build:bundle"
   },
   "dependencies": {

--- a/packages/acala-evm/src/bundle.ts
+++ b/packages/acala-evm/src/bundle.ts
@@ -1,0 +1,6 @@
+// Copyright 2020-2022 OnFinality Limited authors & contributors
+// SPDX-License-Identifier: Apache-2.0
+
+import DatasourcePlugin from '.';
+
+export default DatasourcePlugin;

--- a/packages/acala-evm/tsconfig.json
+++ b/packages/acala-evm/tsconfig.json
@@ -3,10 +3,9 @@
   "compilerOptions": {
     "target": "es2017",
     "sourceMap": true,
-    "tsBuildInfoFile": "dist/.tsbuildinfo",
     "rootDir": "./src",
     "outDir": "./dist",
   },
   "include": ["src/**/*"],
-  "exclude": ["**/*spec.ts"]
+  "exclude": ["**/*spec.ts", "src/bundle.ts"]
 }

--- a/packages/ethermint-evm/tsconfig.json
+++ b/packages/ethermint-evm/tsconfig.json
@@ -3,7 +3,6 @@
   "compilerOptions": {
     "target": "es2017",
     "sourceMap": true,
-    "tsBuildInfoFile": "dist/.tsbuildinfo",
     "rootDir": "./src",
     "outDir": "./dist",
   },

--- a/packages/frontier-evm/package.json
+++ b/packages/frontier-evm/package.json
@@ -7,8 +7,8 @@
   "license": "Apache-2.0",
   "scripts": {
     "build:ts": "tsc -b",
-    "build:bundle": "esbuild src/index.ts --platform=node --bundle --format=cjs --minify --outfile=dist/bundle.js",
-    "build": "yarn build:ts && yarn build:bundle"
+    "build:bundle": "esbuild src/bundle.ts --platform=node --bundle --format=cjs --minify --outfile=dist/bundle.js",
+    "build": "rm -rf dist && yarn build:ts && yarn build:bundle"
   },
   "dependencies": {
     "@subql/types": "latest",

--- a/packages/frontier-evm/src/bundle.ts
+++ b/packages/frontier-evm/src/bundle.ts
@@ -1,0 +1,6 @@
+// Copyright 2020-2022 OnFinality Limited authors & contributors
+// SPDX-License-Identifier: Apache-2.0
+
+import DatasourcePlugin from '.';
+
+export default DatasourcePlugin;

--- a/packages/frontier-evm/tsconfig.json
+++ b/packages/frontier-evm/tsconfig.json
@@ -3,12 +3,11 @@
   "compilerOptions": {
     "target": "es2017",
     "sourceMap": true,
-    "tsBuildInfoFile": "dist/.tsbuildinfo",
     "rootDir": "./src",
     "outDir": "./dist",
   },
   "include": [
     "src/**/*"
   ],
-  "exclude": ["**/*spec.ts"]
+  "exclude": ["**/*spec.ts", "src/bundle.ts"]
 }

--- a/packages/moonbeam-evm/tsconfig.json
+++ b/packages/moonbeam-evm/tsconfig.json
@@ -3,7 +3,6 @@
   "compilerOptions": {
     "target": "es2017",
     "sourceMap": true,
-    "tsBuildInfoFile": "dist/.tsbuildinfo",
     "rootDir": "src",
     "outDir": "./dist",
   },

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,7 +4,7 @@
 
     /* Projects */
     // "incremental": true,                              /* Enable incremental compilation */
-    "composite": true,                                /* Enable constraints that allow a TypeScript project to be used with project references. */
+    "composite": false,                                /* Enable constraints that allow a TypeScript project to be used with project references. */
     // "tsBuildInfoFile": "./",                          /* Specify the folder for .tsbuildinfo incremental compilation files. */
     // "disableSourceOfProjectReferenceRedirect": true,  /* Disable preferring source files instead of declaration files when referencing composite projects */
     // "disableSolutionSearching": true,                 /* Opt a project out of multi-project reference checking when editing. */


### PR DESCRIPTION
Remove EthProvider from the bundle, it is supposed to be used by user's project not as part of the processor.

also I removed the composite settings, got complains when I tried webpack and it is not the case for the processor project. (subpackages don't rely on each other)