### PR TITLE
Remove fs dependency, work around using validation to load abis

### DIFF
--- a/packages/substrate-wasm/src/index.spec.ts
+++ b/packages/substrate-wasm/src/index.spec.ts
@@ -86,8 +86,8 @@ const dsFlip = {
 } as unknown as WasmDatasource;
 
 const assets = {
-  [ERC20_PATH]: fs.readFileSync(ERC20_PATH).toString('utf8'),
-  [FLIP_PATH]: fs.readFileSync(FLIP_PATH).toString('utf8'),
+  erc20: fs.readFileSync(ERC20_PATH).toString('utf8'),
+  flip: fs.readFileSync(FLIP_PATH).toString('utf8'),
 };
 
 describe('WasmDS', () => {

--- a/packages/substrate-wasm/src/index.ts
+++ b/packages/substrate-wasm/src/index.ts
@@ -168,19 +168,18 @@ export function getDsAssets(ds: WasmDatasource, assets?: Record<string, string>)
   if (!abi) {
     throw new Error(`Datasource processor options doesn't specify an abi`);
   }
-  const assetFile = ds.assets?.get(abi);
-  if (!assetFile) {
+  if (!ds.assets?.get(abi)) {
     throw new Error(`Abi named "${abi}" not referenced in assets`);
   }
 
-  if (!dsAssets[assetFile.file]) {
+  if (!dsAssets[abi]) {
     if (!assets) {
       throw new Error(`Unable to load Abi asset for ${abi}`);
     }
-    dsAssets[assetFile.file] = assets[assetFile.file];
+    dsAssets[abi] = assets[abi];
   }
 
-  return dsAssets[assetFile.file];
+  return dsAssets[abi];
 }
 
 export function buildAbi(ds: WasmDatasource, assets?: Record<string, string> | undefined): Abi | undefined {


### PR DESCRIPTION
Removes `fs` dependency to load abis. Instead it uses the validation function to keep the abis in memory. 

Fixes https://github.com/subquery/datasource-processors/issues/39

Depends on https://github.com/subquery/subql/pull/1343 for compat with worker threads.